### PR TITLE
[Reviewer: Ellie] Misc updates (raw mode, gem metadata) and fixes (build on solaris, arity bug)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,22 +15,22 @@ require 'rake'
 require 'jeweler'
 jeweler_tasks = Jeweler::Tasks.new do |gem|
   # gem is a Gem::Specification... see http://docs.rubygems.org/read/chapter/20 for more options
-  gem.name = "lz4-ruby"
-  gem.homepage = "http://github.com/komiya-atsushi/lz4-ruby"
+  gem.name = "lz4-ruby-msw"
+  gem.homepage = "http://github.com/Metaswitch/lz4-ruby"
   gem.license = "MIT"
   gem.summary = %Q{Ruby bindings for LZ4 (Extremely Fast Compression algorithm).}
   gem.description = %Q{Ruby bindings for LZ4. LZ4 is a very fast lossless compression algorithm.}
-  gem.email = "komiya.atsushi@gmail.com"
-  gem.authors = ["KOMIYA Atsushi"]
+  gem.email = "clearwater-support@metaswitch.com"
+  gem.authors = ["KOMIYA Atsushi", "Metaswitch Networks"]
   gem.extensions = ["ext/lz4ruby/extconf.rb"]
-  
+
   gem.files.exclude("*.sh")
-  
+
   gem.files.include("ext/lz4ruby/*.c")
   gem.files.include("ext/lz4ruby/*.h")
 
   gem.required_ruby_version = '>= 1.9'
-  
+
   # dependencies defined in Gemfile
 end
 Jeweler::RubygemsDotOrgTasks.new

--- a/ext/lz4ruby/extconf.rb
+++ b/ext/lz4ruby/extconf.rb
@@ -1,6 +1,13 @@
 require 'mkmf'
+require 'rbconfig'
 
 $CFLAGS += " -Wall "
+
+# On some Solaris systems ruby reports linker flags that are not supported by
+# the linker. Fix this up.
+if RbConfig::CONFIG['host_os'] =~ /solaris|sunos/i
+  $LDFLAGS.gsub!('-Wl,-E', '-Wl,-dy')
+end
 
 create_makefile('lz4ruby')
 

--- a/lib/lz4-ruby.rb
+++ b/lib/lz4-ruby.rb
@@ -18,7 +18,7 @@ class LZ4
   def self.compressHC(input, in_size = nil)
     return _compress(input, in_size, true)
   end
-  
+
   def self.decompress(input, in_size = nil, encoding = nil)
     in_size = input.bytesize if in_size == nil
     out_size, varbyte_len = decode_varbyte(input)
@@ -26,7 +26,7 @@ class LZ4
     if out_size < 0 || varbyte_len < 0
       raise "Compressed data is maybe corrupted"
     end
-    
+
     result = LZ4Internal::uncompress(input, in_size, varbyte_len, out_size)
     result.force_encoding(encoding) if encoding != nil
 
@@ -36,7 +36,7 @@ class LZ4
   def self.compress_with_dict(input, dict, in_size = nil)
     in_size = input.bytesize if in_size == nil
     header = encode_varbyte(in_size)
-    return LZ4Internal.compress_with_dict(header, input, in_size, dict)
+    return LZ4Internal::compress_with_dict(header, input, in_size, dict)
   end
 
   def self.decompress_with_dict(input, dict, in_size = nil, encoding = nil)


### PR DESCRIPTION
Ellie, please can you review these additional changes to the lz4 gem. They are to:
- Support "raw" lz4 compression. The gem can operate in two modes: framed (where the compressed output has the uncompressed size prepended to it) and raw (where it doesn't). You added support for dictionary compression to the framed version only, whereas we want to use raw mode instead. I've mirrored the API to the existing raw functions - most notably when decompressing raw data the user must supply the maximum message size on the decompress calls.
- Make the gem build on Solaris. 
- Update the author and gem name. 
- Fixed an "incorrect number of arguments" bug (which seemed to be caused by using a `.` instead of a `::`)
